### PR TITLE
feature: Implement charge method in PointService class

### DIFF
--- a/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/common/SystemTimeUtil.kt
+++ b/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/common/SystemTimeUtil.kt
@@ -1,0 +1,10 @@
+package io.hhplus.tdd.common
+
+import org.springframework.stereotype.Component
+
+@Component
+class SystemTimeUtil: TimeUtil {
+    override fun getCurrentTimeInMilliSeconds(): Long {
+        return System.currentTimeMillis()
+    }
+}

--- a/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/common/TimeUtil.kt
+++ b/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/common/TimeUtil.kt
@@ -1,0 +1,5 @@
+package io.hhplus.tdd.common
+
+interface TimeUtil {
+    fun getCurrentTimeInMilliSeconds(): Long
+}

--- a/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointException.kt
+++ b/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointException.kt
@@ -1,0 +1,5 @@
+package io.hhplus.tdd.point
+
+sealed class PointException(message: String): Exception(message) {
+    class IllegalAmountChargeException(message: String): PointException(message = message)
+}

--- a/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointException.kt
+++ b/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointException.kt
@@ -1,5 +1,5 @@
 package io.hhplus.tdd.point
 
-sealed class PointException(message: String): Exception(message) {
+sealed class PointException(message: String): RuntimeException(message) {
     class IllegalAmountChargeException(message: String): PointException(message = message)
 }

--- a/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -1,0 +1,24 @@
+package io.hhplus.tdd.point
+
+import io.hhplus.tdd.common.TimeUtil
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.database.UserPointTable
+import org.springframework.stereotype.Service
+
+@Service
+class PointService(
+    private val userPointTable: UserPointTable,
+    private val pointHistoryTable: PointHistoryTable,
+    private val timeUtil: TimeUtil
+) {
+    fun charge(userId: Long, amount: Long): UserPoint {
+        /*** Flow
+         * 1. Get existent UserPoint
+         * 2. Add an amount from request
+         *   2-1. If the total amount is over the policy, throw exception.
+         *      - cf. We currently set the maximum point to 100,000.
+         * 3. Add a history
+         */
+        TODO("Will be implemented in another commit.")
+    }
+}

--- a/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/FakeTimeUtil.kt
+++ b/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/FakeTimeUtil.kt
@@ -1,0 +1,11 @@
+package io.hhplus.tdd
+
+import io.hhplus.tdd.common.TimeUtil
+
+class FakeTimeUtil(
+    private val fixedTime: Long
+): TimeUtil {
+    override fun getCurrentTimeInMilliSeconds(): Long {
+        return fixedTime
+    }
+}

--- a/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
+++ b/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
@@ -69,9 +69,9 @@ class PointServiceTest {
     fun givenExistingPoints_whenChargingPointsOverMaximum_ThenThrowException() {
         // Given
         val userId = 1L
-        val existingPoint = 10000L
-        val amount = 90001L
-        val fakeUpdateMilliseconds = 1000L
+        val existingPoint = 10_000L
+        val amount = 90_001L
+        val fakeUpdateMilliseconds = 1_000L
 
         val userPointTable = mock(UserPointTable::class.java)
         val pointHistoryTableMock = mock(PointHistoryTable::class.java)

--- a/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
+++ b/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
@@ -1,0 +1,65 @@
+package io.hhplus.tdd
+
+import io.hhplus.tdd.database.PointHistoryTable
+import io.hhplus.tdd.database.UserPointTable
+import io.hhplus.tdd.point.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.*
+
+class PointServiceTest {
+    @Test
+    @DisplayName("Given 10,000 existing points, When charging 90,000 points, Then total becoming 100,000 points successfully.")
+    fun givenExistingPoints_whenChargingPoints_ThenAddingPointsSuccessfully() {
+        // Given
+        val userId = 1L
+        val existingPoint = 10_000L
+        val amount = 90_000L
+        val fakeUpdateMilliseconds = 1_000L
+
+        val userPointTable = mock(UserPointTable::class.java)
+        val pointHistoryTableMock = mock(PointHistoryTable::class.java)
+        val fakeTimeUtil = FakeTimeUtil(fixedTime = fakeUpdateMilliseconds)
+
+        val pointService = PointService(userPointTable = userPointTable, pointHistoryTable = pointHistoryTableMock, timeUtil = fakeTimeUtil)
+
+        `when`(userPointTable.selectById(id = userId))
+            .thenReturn(UserPoint(id = userId, point = existingPoint, updateMillis = fakeUpdateMilliseconds))
+        `when`(userPointTable.insertOrUpdate(id = userId, amount = existingPoint + amount))
+            .thenReturn(UserPoint(id = userId, point = existingPoint + amount, updateMillis = fakeUpdateMilliseconds))
+        `when`(
+            pointHistoryTableMock.insert(
+                id = userId,
+                amount = amount,
+                transactionType = TransactionType.CHARGE,
+                updateMillis = fakeUpdateMilliseconds
+            )
+        ).thenReturn(
+            PointHistory(
+                id = 1L,
+                userId = userId,
+                amount = amount,
+                type = TransactionType.CHARGE,
+                timeMillis = fakeUpdateMilliseconds
+            )
+        )
+
+        // When
+        val result = pointService.charge(userId = userId, amount = amount)
+
+        // Then
+        assertThat(result)
+            .isEqualTo(UserPoint(id = userId, point = existingPoint + amount, updateMillis = fakeUpdateMilliseconds))
+
+        verify(userPointTable, times(1)).selectById(id = userId)
+        verify(userPointTable, times(1)).insertOrUpdate(id = userId, amount = existingPoint + amount)
+        verify(pointHistoryTableMock, times(1))
+            .insert(
+                id = userId,
+                amount = amount,
+                transactionType = TransactionType.CHARGE,
+                updateMillis = fakeUpdateMilliseconds
+            )
+    }
+}

--- a/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
+++ b/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
@@ -6,6 +6,7 @@ import io.hhplus.tdd.point.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.*
 
 class PointServiceTest {
@@ -61,5 +62,34 @@ class PointServiceTest {
                 transactionType = TransactionType.CHARGE,
                 updateMillis = fakeUpdateMilliseconds
             )
+    }
+
+    @Test
+    @DisplayName("Given 10,000 existing points, When charging 90,001 points, Then throw IllegalAmountChargeException.")
+    fun givenExistingPoints_whenChargingPointsOverMaximum_ThenThrowException() {
+        // Given
+        val userId = 1L
+        val existingPoint = 10000L
+        val amount = 90001L
+        val fakeUpdateMilliseconds = 1000L
+
+        val userPointTable = mock(UserPointTable::class.java)
+        val pointHistoryTableMock = mock(PointHistoryTable::class.java)
+        val fakeTimeUtil = FakeTimeUtil(fixedTime = fakeUpdateMilliseconds)
+
+        val pointService = PointService(userPointTable = userPointTable, pointHistoryTable = pointHistoryTableMock, timeUtil = fakeTimeUtil)
+
+        `when`(userPointTable.selectById(id = userId)).
+        thenReturn(UserPoint(id = userId, point = existingPoint, updateMillis = fakeUpdateMilliseconds))
+
+        // When
+        // Then
+        assertThrows<PointException.IllegalAmountChargeException> {
+            pointService.charge(userId = userId, amount = amount)
+        }
+
+        verify(userPointTable, times(1)).selectById(id = userId)
+        verify(userPointTable, never()).insertOrUpdate(id = userId, amount = existingPoint + amount)
+        verify(pointHistoryTableMock, never()).insert(id = userId, amount = amount, transactionType = TransactionType.CHARGE, updateMillis = fakeUpdateMilliseconds)
     }
 }


### PR DESCRIPTION
### **커밋 설명**

<!--
좋은 피드백을 받기 위해 가장 중요한 것은 커밋입니다.
코드를 작성할 때 커밋을 작업 단위로 잘 쪼개주세요!

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- 현재 시간 계산을 위해 사용되는 유틸 성격의 클래스 추가: c7f38a5
- `charge` 메서드에 대한 인터페이스 추가: 304e9ba
- `charge` 메서드에 대한 성공 테스트 케이스 추가: 686df0b
- 정해진 최대 충전량을 넘을 경우를 처리하기 위한 사용자 정의 예외 추가: 53d2b0a
- `charge` 메서드에 대해 정해진 최대 충전량이 넘을 경우에 대한 실패 테스트 케이스 추가: a0395fb
- `charge` 메서드 구현 ddcdbe7
- 기존 `Exception` 상속 받아 정의했던 `PointException` 클래스 `RuntimeException` 상속으로 변경: ddcdbe7

---

### **리뷰 받고 싶은 내용(질문)**

#### 불필요한 추상화에 대한 부분

- 서비스 계층에 대한 인터페이스 및 기존 구현되어 있던 `xxxTable` 관련 클래스에 대한 레포지토리 계층 추상화를 별도로 진행하지 않았습니다.
- 과제 및 현재 구현해야 할 애플리케이션이 서비스 계층에 집중해야 할 것으로 판단했으며, PointService에 대한 여러 구현체가 필요한 상황 또는 스토리지에 해당하는 레포지토리 계층 쪽에 구현체가 여러 개로 나뉘어야 할 상황은 아니라 판단 했습니다.
- 혹시 앞으로 과제 중에 이러한 부분도 고려가 필요한지 조언 구하고 싶습니다.

#### 동시성 관련 깨지는 테스트 코드

- #26 PR 통해서 확인해보실 경우 [충전 이후 조회가 순서대로 이루어지게 하는 경우](https://github.com/0417taehyun/hanghae-plus-lite/pull/26/files#diff-ff7dba7cc489c461ea94304ce81bc6ff1a59366572bd8bebbf258459ae0d12f5R414-R459)와 [충전 이후 내역조회가 순서대로 이루어지게 하는 경우](https://github.com/0417taehyun/hanghae-plus-lite/pull/26/files#diff-ff7dba7cc489c461ea94304ce81bc6ff1a59366572bd8bebbf258459ae0d12f5R461-R507)가 간헐적으로 실패하고 있습니다.
- 저는 `userId` 값 기준으로 ReentrantLock을 사용하고 있어서 트랜잭션 순서대로 잠금이 발생해 테스트가 깨지지 않아야 할 거라 생각했는데, 원인을 잘 모르겠어서요.
- 동시성 관련 코드와 테스트 코드를 처음 작성해봐서 그런데 어떤 방향으로 작성해야 하는 지 조언 구하고 싶습니다.

<!-- - 코드 리뷰에서 피드백 받고 싶은 포인트가 있다면 추가로 작성해주세요

  좋은 예:
  - 커밋 : 동시성 테스트 코드 d93ji3
  - 내용 `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.

  - 커밋 : 동시성 처리 c83845 / 혹은 파일명
  - 내용 : 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->

---

### 기타 참고

> Stacked Pull Request 형태로 작업했기 때문에 하기 PR 이어서 리뷰 필요

#### 이어지는 Pull Request

1. #15
2. #16
3. #17  
4. #25 
5. #26
