### PR TITLE
feature: Implement getHistories method in PointService class

### DIFF
--- a/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -44,10 +44,7 @@ class PointService(
     }
 
     fun getHistories(userId: Long): List<PointHistory> {
-        /*** Flow
-         * 1. Get a list of PointHistory by using userId
-         */
-        TODO("Will be implemented in another commit.")
+        return pointHistoryTable.selectAllByUserId(userId = userId)
     }
 
     companion object {

--- a/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
+++ b/w01/hhplus-tdd-jvm/src/main/kotlin/io/hhplus/tdd/point/PointService.kt
@@ -43,6 +43,13 @@ class PointService(
         return userPointTable.selectById(id = userId)
     }
 
+    fun getHistories(userId: Long): List<PointHistory> {
+        /*** Flow
+         * 1. Get a list of PointHistory by using userId
+         */
+        TODO("Will be implemented in another commit.")
+    }
+
     companion object {
         private const val MAXIMUM_POINT = 100_000L
     }

--- a/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
+++ b/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
@@ -206,7 +206,7 @@ class PointServiceTest {
         // Given
         val userId = 1L
         val amount = 10_000L
-        val fakeUpdateMilliseconds = 1000L
+        val fakeUpdateMilliseconds = 1_000L
 
         val userPointTable = mock(UserPointTable::class.java)
         val pointHistoryTableMock = mock(PointHistoryTable::class.java)

--- a/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
+++ b/w01/hhplus-tdd-jvm/src/test/kotlin/io/hhplus/tdd/PointServiceTest.kt
@@ -199,4 +199,30 @@ class PointServiceTest {
         // Then
         assertThat(result).isEqualTo(UserPoint(id = userId, point = existingPoint, updateMillis = fakeUpdateMilliseconds))
     }
+
+    @Test
+    @DisplayName("Given two transactions, When passing matched user id, Then returning a history of two transactions successfully.")
+    fun givenExistingPointHistory_whenPassingMatchedUserId_ThenReturningListOfPointHistorySuccessfully() {
+        // Given
+        val userId = 1L
+        val amount = 10_000L
+        val fakeUpdateMilliseconds = 1000L
+
+        val userPointTable = mock(UserPointTable::class.java)
+        val pointHistoryTableMock = mock(PointHistoryTable::class.java)
+        val fakeTimeUtil = FakeTimeUtil(fixedTime = fakeUpdateMilliseconds)
+
+        val pointService = PointService(userPointTable = userPointTable, pointHistoryTable = pointHistoryTableMock, timeUtil = fakeTimeUtil)
+
+        val chargeTransaction = PointHistory(id = 1L, userId = userId, type = TransactionType.CHARGE, amount = amount, timeMillis = fakeUpdateMilliseconds)
+        val useTransaction = PointHistory(id = 2L, userId = userId, type = TransactionType.USE, amount = amount, timeMillis = fakeUpdateMilliseconds)
+
+        `when`(pointHistoryTableMock.selectAllByUserId(userId = userId)).thenReturn(listOf(chargeTransaction, useTransaction))
+
+        // When
+        val result = pointService.getHistories(userId = userId)
+
+        // Then
+        assertThat(result).isEqualTo(listOf(chargeTransaction, useTransaction))
+    }
 }


### PR DESCRIPTION
### **커밋 설명**

<!--
좋은 피드백을 받기 위해 가장 중요한 것은 커밋입니다.
코드를 작성할 때 커밋을 작업 단위로 잘 쪼개주세요!

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- `getHistories` 메서드에 대한 인터페이스 추가: 91782da
- `getHistories` 메서드에 대한 성공 테스트 케이스 추가: 0537987
- `getHistories` 메서드 구현: dc4da47
-  테스트 케이스에서 사용되는 Long 타입의 숫자 가독성 향상: 976b457

---

### 기타 참고

> Stacked Pull Request 형태로 작업했기 때문에 하기 PR 선행 및 이어서 리뷰 필요

#### 선행되는 Pull Request

1. #13 
2. #15 
3. #16 

#### 이어지는 Pull Request

1. #25 
2. #26
